### PR TITLE
consistent identation

### DIFF
--- a/themes/iterm.yaml
+++ b/themes/iterm.yaml
@@ -1,28 +1,28 @@
 # Colors (iTerm 2 default theme)
 colors:
- # Default colors
- primary:
-   background: '0x101421'
-   foreground: '0xfffbf6'
+  # Default colors
+  primary:
+    background: '0x101421'
+    foreground: '0xfffbf6'
 
- # Normal colors
- normal:
-   black:   '0x2e2e2e'
-   red:     '0xeb4129'
-   green:   '0xabe047'
-   yellow:  '0xf6c744'
-   blue:    '0x47a0f3'
-   magenta: '0x7b5cb0'
-   cyan:    '0x64dbed'
-   white:   '0xe5e9f0'
+  # Normal colors
+  normal:
+    black:   '0x2e2e2e'
+    red:     '0xeb4129'
+    green:   '0xabe047'
+    yellow:  '0xf6c744'
+    blue:    '0x47a0f3'
+    magenta: '0x7b5cb0'
+    cyan:    '0x64dbed'
+    white:   '0xe5e9f0'
 
- # Bright colors
- bright:
-   black:   '0x565656'
-   red:     '0xec5357'
-   green:   '0xc0e17d'
-   yellow:  '0xf9da6a'
-   blue:    '0x49a4f8'
-   magenta: '0xa47de9'
-   cyan:    '0x99faf2'
-   white:   '0xffffff'
+  # Bright colors
+  bright:
+    black:   '0x565656'
+    red:     '0xec5357'
+    green:   '0xc0e17d'
+    yellow:  '0xf9da6a'
+    blue:    '0x49a4f8'
+    magenta: '0xa47de9'
+    cyan:    '0x99faf2'
+    white:   '0xffffff'

--- a/themes/nord.yaml
+++ b/themes/nord.yaml
@@ -1,28 +1,28 @@
 # Colors (Nord)
 colors:
-   # Default colors
-   primary:
-     background: '0x2E3440'
-     foreground: '0xD8DEE9'
+  # Default colors
+  primary:
+    background: '0x2E3440'
+    foreground: '0xD8DEE9'
 
-   # Normal colors
-   normal:
-     black:   '0x3B4252'
-     red:     '0xBF616A'
-     green:   '0xA3BE8C'
-     yellow:  '0xEBCB8B'
-     blue:    '0x81A1C1'
-     magenta: '0xB48EAD'
-     cyan:    '0x88C0D0'
-     white:   '0xE5E9F0'
+  # Normal colors
+  normal:
+    black:   '0x3B4252'
+    red:     '0xBF616A'
+    green:   '0xA3BE8C'
+    yellow:  '0xEBCB8B'
+    blue:    '0x81A1C1'
+    magenta: '0xB48EAD'
+    cyan:    '0x88C0D0'
+    white:   '0xE5E9F0'
 
-   # Bright colors
-   bright:
-     black:   '0x4C566A'
-     red:     '0xBF616A'
-     green:   '0xA3BE8C'
-     yellow:  '0xEBCB8B'
-     blue:    '0x81A1C1'
-     magenta: '0xB48EAD'
-     cyan:    '0x8FBCBB'
-     white:   '0xECEFF4'
+  # Bright colors
+  bright:
+    black:   '0x4C566A'
+    red:     '0xBF616A'
+    green:   '0xA3BE8C'
+    yellow:  '0xEBCB8B'
+    blue:    '0x81A1C1'
+    magenta: '0xB48EAD'
+    cyan:    '0x8FBCBB'
+    white:   '0xECEFF4'

--- a/themes/pencil_dark.yaml
+++ b/themes/pencil_dark.yaml
@@ -1,26 +1,26 @@
 # Colors (Pencil Dark)
 colors:
- # Default Colors
- primary:
-   background: '0x212121'
-   foreground: '0xf1f1f1'
- # Normal colors
- normal:
-   black:   '0x212121'
-   red:     '0xc30771'
-   green:   '0x10a778'
-   yellow:  '0xa89c14'
-   blue:    '0x008ec4'
-   magenta: '0x523c79'
-   cyan:    '0x20a5ba'
-   white:   '0xe0e0e0'
- # Bright colors
- bright:
-   black:   '0x212121'
-   red:     '0xfb007a'
-   green:   '0x5fd7af'
-   yellow:  '0xf3e430'
-   blue:    '0x20bbfc'
-   magenta: '0x6855de'
-   cyan:    '0x4fb8cc'
-   white:   '0xf1f1f1'
+  # Default Colors
+  primary:
+    background: '0x212121'
+    foreground: '0xf1f1f1'
+  # Normal colors
+  normal:
+    black:   '0x212121'
+    red:     '0xc30771'
+    green:   '0x10a778'
+    yellow:  '0xa89c14'
+    blue:    '0x008ec4'
+    magenta: '0x523c79'
+    cyan:    '0x20a5ba'
+    white:   '0xe0e0e0'
+  # Bright colors
+  bright:
+    black:   '0x212121'
+    red:     '0xfb007a'
+    green:   '0x5fd7af'
+    yellow:  '0xf3e430'
+    blue:    '0x20bbfc'
+    magenta: '0x6855de'
+    cyan:    '0x4fb8cc'
+    white:   '0xf1f1f1'

--- a/themes/pencil_light.yaml
+++ b/themes/pencil_light.yaml
@@ -1,26 +1,26 @@
 # Colors (Pencil Light)
 colors:
- # Default Colors
- primary:
-   background: '0xf1f1f1'
-   foreground: '0x424242'
- # Normal colors
- normal:
-   black:   '0x212121'
-   red:     '0xc30771'
-   green:   '0x10a778'
-   yellow:  '0xa89c14'
-   blue:    '0x008ec4'
-   magenta: '0x523c79'
-   cyan:    '0x20a5ba'
-   white:   '0xe0e0e0'
- # Bright colors
- bright:
-   black:   '0x212121'
-   red:     '0xfb007a'
-   green:   '0x5fd7af'
-   yellow:  '0xf3e430'
-   blue:    '0x20bbfc'
-   magenta: '0x6855de'
-   cyan:    '0x4fb8cc'
-   white:   '0xf1f1f1'
+  # Default Colors
+  primary:
+    background: '0xf1f1f1'
+    foreground: '0x424242'
+  # Normal colors
+  normal:
+    black:   '0x212121'
+    red:     '0xc30771'
+    green:   '0x10a778'
+    yellow:  '0xa89c14'
+    blue:    '0x008ec4'
+    magenta: '0x523c79'
+    cyan:    '0x20a5ba'
+    white:   '0xe0e0e0'
+  # Bright colors
+  bright:
+    black:   '0x212121'
+    red:     '0xfb007a'
+    green:   '0x5fd7af'
+    yellow:  '0xf3e430'
+    blue:    '0x20bbfc'
+    magenta: '0x6855de'
+    cyan:    '0x4fb8cc'
+    white:   '0xf1f1f1'

--- a/themes/xterm.yaml
+++ b/themes/xterm.yaml
@@ -1,27 +1,27 @@
 # XTerm's default colors
 colors:
-   # Default colors
-   primary:
-     background: '0x000000'
-     foreground: '0xffffff'
-   # Normal colors
-   normal:
-     black:   '0x000000'
-     red:     '0xcd0000'
-     green:   '0x00cd00'
-     yellow:  '0xcdcd00'
-     blue:    '0x0000ee'
-     magenta: '0xcd00cd'
-     cyan:    '0x00cdcd'
-     white:   '0xe5e5e5'
+  # Default colors
+  primary:
+    background: '0x000000'
+    foreground: '0xffffff'
+  # Normal colors
+  normal:
+    black:   '0x000000'
+    red:     '0xcd0000'
+    green:   '0x00cd00'
+    yellow:  '0xcdcd00'
+    blue:    '0x0000ee'
+    magenta: '0xcd00cd'
+    cyan:    '0x00cdcd'
+    white:   '0xe5e5e5'
 
-   # Bright colors
-   bright:
-     black:   '0x7f7f7f'
-     red:     '0xff0000'
-     green:   '0x00ff00'
-     yellow:  '0xffff00'
-     blue:    '0x5c5cff'
-     magenta: '0xff00ff'
-     cyan:    '0x00ffff'
-     white:   '0xffffff'
+  # Bright colors
+  bright:
+    black:   '0x7f7f7f'
+    red:     '0xff0000'
+    green:   '0x00ff00'
+    yellow:  '0xffff00'
+    blue:    '0x5c5cff'
+    magenta: '0xff00ff'
+    cyan:    '0x00ffff'
+    white:   '0xffffff'


### PR DESCRIPTION
Fix inconsistent indentation. If I use the themes as is in Alacritty 0.3.2, I get the following error on five themes:

> [ERROR] Unable to load config "/home/jan/.config/alacritty/alacritty.yml": Problem with config: while parsing a block mapping, did not find expected key at line 218 column 17

After fixing identation-levels in those files the errors go away.