### PR TITLE
Add Doom One Theme (from Doom Emacs)

### DIFF
--- a/themes/doom_one.yml
+++ b/themes/doom_one.yml
@@ -1,0 +1,17 @@
+# Colors (Doom One)
+colors:
+  # Default colors
+  primary:
+    background: '0x282c34'
+    foreground: '0xbbc2cf'
+
+  # Normal colors
+  normal:
+    black:   '0x282c34'
+    red:     '0xff6c6b'
+    green:   '0x98be65'
+    yellow:  '0xecbe7b'
+    blue:    '0x51afef'
+    magenta: '0xc678dd'
+    cyan:    '0x46d9ff'
+    white:   '0xbbc2cf'


### PR DESCRIPTION
This theme is crudely copied from the emacs theme [Doom One](https://github.com/hlissner/emacs-doom-themes/blob/master/themes/doom-one-theme.el). As an example, see the attached screenshot showing it side-by-side with an emacs buffer using the real theme. 

![doom-one-screenshot](https://user-images.githubusercontent.com/15976214/71608435-55326c00-2b4f-11ea-93e0-c99cd1aa7b9f.png)
