### PR TITLE
Addition to two common color scheme to repo

### DIFF
--- a/themes/flat_remix.yml
+++ b/themes/flat_remix.yml
@@ -1,0 +1,25 @@
+ flat_remix: &flat_remix
+        primary:
+          background: '0x272a34'
+          foreground: '0xFFFFFF'
+
+        normal:
+            black:   '0x1F2229'           # Black
+            red:     '0xEC0101'           # Light Red
+            green:   '0x47D4B9'           # Light Green
+            yellow:  '0xFF8A18'           # Light Yellow
+            blue:    '0x277FFF'           # Light Blue
+            magenta: '0xD71655'           # Light Magenta
+            cyan:    '0x05A1F7'           # Light Cyan
+            white:   '0xFFFFFF'           # White
+           
+
+        bright:
+            black:     	'0x1F2229'           # Black
+            red:       	'0xD41919'           # Red
+            green:     	'0x5EBDAB'           # Green
+            yellow:    	'0xFEA44C'           # Yellow
+            blue:      	'0x367bf0'           # Blue
+            magenta:   	'0xBF2E5D'           # Magenta
+            cyan:      	'0x49AEE6'           # Cyan
+            white:      '0xFFFFFF' 

--- a/themes/gruvbox_material.yml
+++ b/themes/gruvbox_material.yml
@@ -1,0 +1,26 @@
+# Colors (Gruvbox Material Dark Medium)
+    colors:
+        primary:
+          background: '0x282828'
+          foreground: '0xdfbf8e'
+
+        normal:
+          black:   '0x665c54'
+          red:     '0xea6962'
+          green:   '0xa9b665'
+          yellow:  '0xe78a4e'
+          blue:    '0x7daea3'
+          magenta: '0xd3869b'
+          cyan:    '0x89b482'
+          white:   '0xdfbf8e'
+
+        bright:
+          black:   '0x928374'
+          red:     '0xea6962'
+          green:   '0xa9b665'
+          yellow:  '0xe3a84e'
+          blue:    '0x7daea3'
+          magenta: '0xd3869b'
+          cyan:    '0x89b482'
+          white:   '0xdfbf8e'
+ 


### PR DESCRIPTION
Ported flat remix colorscheme from [Mayccoll/Gogh](https://github.com/Mayccoll/Gogh)
![Screenshot from 2020-07-08 11-44-34](https://user-images.githubusercontent.com/8735356/86884314-06264e80-c111-11ea-8456-7d4bdcafcd21.png)

Adpated [Gruvbox_material](https://github.com/sainnhe/gruvbox-material) theme  (originally for vim)
![Screenshot from 2020-07-08 11-19-08](https://user-images.githubusercontent.com/8735356/86884475-3cfc6480-c111-11ea-86eb-f922fdd70eec.png)
