### PR TITLE
Add Tokyo Night theme (and "storm" variant)

### DIFF
--- a/themes/tokyo-night-storm.yaml
+++ b/themes/tokyo-night-storm.yaml
@@ -1,0 +1,29 @@
+# Colors (Tokyo Night: Storm variant)
+# Source: https://github.com/zatchheems/tokyo-night-alacritty-theme
+colors:
+  # Default colors
+  primary:
+    background: '0x24283b'
+    foreground: '0xa9b1d6'
+
+  # Normal colors
+  normal:
+    black:   '0x32344a'
+    red:     '0xf7768e'
+    green:   '0x9ece6a'
+    yellow:  '0xe0af68'
+    blue:    '0x7aa2f7'
+    magenta: '0xad8ee6'
+    cyan:    '0x449dab'
+    white:   '0x9699a8'
+
+  # Bright colors
+  bright:
+    black:   '0x444b6a'
+    red:     '0xff7a93'
+    green:   '0xb9f27c'
+    yellow:  '0xff9e64'
+    blue:    '0x7da6ff'
+    magenta: '0xbb9af7'
+    cyan:    '0x0db9d7'
+    white:   '0xacb0d0'

--- a/themes/tokyo-night.yaml
+++ b/themes/tokyo-night.yaml
@@ -1,0 +1,29 @@
+# Colors (Tokyo Night)
+# Source: https://github.com/zatchheems/tokyo-night-alacritty-theme
+colors:
+  # Default colors
+  primary:
+    background: '0x1a1b26'
+    foreground: '0xa9b1d6'
+
+  # Normal colors
+  normal:
+    black:   '0x32344a'
+    red:     '0xf7768e'
+    green:   '0x9ece6a'
+    yellow:  '0xe0af68'
+    blue:    '0x7aa2f7'
+    magenta: '0xad8ee6'
+    cyan:    '0x449dab'
+    white:   '0x787c99'
+
+  # Bright colors
+  bright:
+    black:   '0x444b6a'
+    red:     '0xff7a93'
+    green:   '0xb9f27c'
+    yellow:  '0xff9e64'
+    blue:    '0x7da6ff'
+    magenta: '0xbb9af7'
+    cyan:    '0x0db9d7'
+    white:   '0xacb0d0'


### PR DESCRIPTION
Hello! I'd like to add Tokyo Night: originally a [VS Code theme](https://github.com/enkia/tokyo-night-vscode-theme), then ported from the [Vim theme](https://github.com/ghifarit53/tokyonight-vim).

![screen_shot_2020-10-18_at_12 09 05_pm](https://user-images.githubusercontent.com/8506829/96374927-629b0000-113b-11eb-95f1-9b7b4f9630f9.png)
Source [here](https://github.com/zatchheems/tokyo-night-alacritty-theme).
