### PR TITLE
Added Linux Colors theme ported from Konsole

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Or use [alacritty-colorscheme](https://github.com/toggle-corp/alacritty-colorsch
 |**_horizon-dark_**<br>[source](https://github.com/jolaleye/horizon-theme-vscode)|![horizon-dark](images/horizon-dark.png)|
 |**_hyper_**<br>[source](https://hyper.is)|![hyper](images/hyper.png)|
 |**_iterm_**|![iterm](images/iterm.png)|
+|**_konsole_linux_**|TBD|
 |**_low_contrast_**|![iterm](images/low_contrast.png)|
 |**_material_theme_**<br>[source](https://github.com/equinusocio/material-theme)|![material_theme](images/material_theme.png)|
 |**_material_theme_mod_**|![material_theme](images/material_theme_mod.png)|

--- a/schemes.yaml
+++ b/schemes.yaml
@@ -599,6 +599,52 @@ schemes:
       cyan:    '0x99faf2'
       white:   '0xffffff'
 
+  konsole_linux: &konsole_linux
+    primary:
+      foreground: '0xe3e3e3'
+      bright_foreground: '0xffffff'
+      dim_foreground:    '0xe3e3e3'
+      background: '0x1f1f1f'
+      bright_background: '0x686868' # not sure
+      dim_background:    '0x1f1f1f' # not sure
+    cursor:
+      text: '0x191622'
+      cursor: '0xf8f8f2'
+    search:
+      matches:
+        foreground: '0xb2b2b2'
+        background: '0xb26818'
+      focused_match:
+        foreground: CellBackground
+        background: CellForeground
+    normal:
+      black:   '0x000000'
+      red:     '0xb21818'
+      green:   '0x18b218'
+      yellow:  '0xb26818'
+      blue:    '0x1818b2'
+      magenta: '0xb218b2'
+      cyan:    '0x18b2b2'
+      white:   '0xb2b2b2'
+    bright:
+      black:   '0x686868'
+      red:     '0xff5454'
+      green:   '0x54ff54'
+      yellow:  '0xffff54'
+      blue:    '0x5454ff'
+      magenta: '0xff54ff'
+      cyan:    '0x54ffff'
+      white:   '0xffffff'
+    dim:
+      black:   '0x000000'
+      red:     '0xb21818'
+      green:   '0x18b218'
+      yellow:  '0xb26818'
+      blue:    '0x1818b2'
+      magenta: '0xb218b2'
+      cyan:    '0x18b2b2'
+      white:   '0xb2b2b2'
+
   low_contrast: &low_contrast
     primary:
       background: '0x333333'

--- a/themes/konsole_linux.yaml
+++ b/themes/konsole_linux.yaml
@@ -1,0 +1,51 @@
+# Color theme ported from Konsole: Linux colors 
+colors:  
+  primary:
+    foreground: '0xe3e3e3'
+    bright_foreground: '0xffffff'
+    dim_foreground:    '0xe3e3e3'
+    background: '0x1f1f1f'
+    bright_background: '0x686868' # not sure
+    dim_background:    '0x1f1f1f' # not sure
+
+  cursor:
+    text: '0x191622'
+    cursor: '0xf8f8f2'
+
+  search:
+    matches:
+      foreground: '0xb2b2b2'
+      background: '0xb26818'
+    focused_match:
+      foreground: CellBackground
+      background: CellForeground
+
+  normal:
+    black:   '0x000000'
+    red:     '0xb21818'
+    green:   '0x18b218'
+    yellow:  '0xb26818'
+    blue:    '0x1818b2'
+    magenta: '0xb218b2'
+    cyan:    '0x18b2b2'
+    white:   '0xb2b2b2'
+
+  bright:
+    black:   '0x686868'
+    red:     '0xff5454'
+    green:   '0x54ff54'
+    yellow:  '0xffff54'
+    blue:    '0x5454ff'
+    magenta: '0xff54ff'
+    cyan:    '0x54ffff'
+    white:   '0xffffff'
+
+  dim:
+    black:   '0x000000'
+    red:     '0xb21818'
+    green:   '0x18b218'
+    yellow:  '0xb26818'
+    blue:    '0x1818b2'
+    magenta: '0xb218b2'
+    cyan:    '0x18b2b2'
+    white:   '0xb2b2b2'


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Placed theme file in `themes` directory
- [x] Updated `schemes.yaml` file

* **Link to the source repository**

Ported from the standart Konsole themes pack: https://github.com/KDE/konsole/blob/master/data/color-schemes/Linux.colorscheme

* **Modifications**

- [x] Copied from source without modification
  * Note, scheme includes settings for Search highlighting, that out of scope of the Konsole theme. But colors from the original Konsole theme is used.
- [ ] Minor modifications (changed few colors for clear visibility)
- [ ] Heavily modified (almost all the colors are modified)
