### PR TITLE
add smoooooth theme from iTerm2

### DIFF
--- a/schemes.yaml
+++ b/schemes.yaml
@@ -1095,6 +1095,35 @@ schemes:
       cyan: '0x97b9c0'
       white: '0xffe9d7'
 
+  smoooooth: &smoooooth
+    primary:
+      foreground: '0xdbdbdb'
+      background: '0x14191e'
+    cursor:
+      text: '0x000000'
+      cursor: '0xfefffe'
+    selection:
+      text: '0x000000'
+      background: '0xb3d7ff'
+    normal:
+      black:   '0x14191e'
+      red:     '0xb43c29'
+      green:   '0x00c200'
+      yellow:  '0xc7c400'
+      blue:    '0x2743c7'
+      magenta: '0xbf3fbd'
+      cyan:    '0x00c5c7'
+      white:   '0xc7c7c7'
+    bright:
+      black:   '0x676767'
+      red:     '0xdc7974'
+      green:   '0x57e690'
+      yellow:  '0xece100'
+      blue:    '0xa6aaf1'
+      magenta: '0xe07de0'
+      cyan:    '0x5ffdff'
+      white:   '0xfeffff'
+
   solarized_dark: &solarized_dark
     primary:
       background: '0x002b36'

--- a/themes/smoooooth.yml
+++ b/themes/smoooooth.yml
@@ -1,0 +1,30 @@
+# Color theme ported from iTerm 2: Smoooooth
+
+colors:  
+  primary:
+    foreground: '0xdbdbdb'
+    background: '0x14191e'
+  cursor:
+    text: '0x000000'
+    cursor: '0xfefffe'
+  selection:
+    text: '0x000000'
+    background: '0xb3d7ff'
+  normal:
+    black:   '0x14191e'
+    red:     '0xb43c29'
+    green:   '0x00c200'
+    yellow:  '0xc7c400'
+    blue:    '0x2743c7'
+    magenta: '0xbf3fbd'
+    cyan:    '0x00c5c7'
+    white:   '0xc7c7c7'
+  bright:
+    black:   '0x676767'
+    red:     '0xdc7974'
+    green:   '0x57e690'
+    yellow:  '0xece100'
+    blue:    '0xa6aaf1'
+    magenta: '0xe07de0'
+    cyan:    '0x5ffdff'
+    white:   '0xfeffff'


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Placed theme file in `themes` directory
- [x] Updated `schemes.yaml` file

* **Link to the source repository**

https://github.com/gnachman/iTerm2/blob/33945e63ad48ed80d6cc1adf7cbeb663217652d2/plists/ColorPresets.plist#L4345-L4685

iTerm color presets are defined in real numbers in XML file. I used color-picker interface in preferences window to get hex values and put them to theme by hand.

* **Modifications**

- [x] Copied from source without modification
- [ ] Minor modifications (changed few colors for clear visibility)
- [ ] Heavily modified (almost all the colors are modified)
